### PR TITLE
Feature/badgebook server token auth

### DIFF
--- a/src/server/api/models/permissionSet.js
+++ b/src/server/api/models/permissionSet.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const permissionSetSchema = mongoose.Schema({
+    _id: mongoose.Schema.Types.ObjectId,
+    clientId: String,
+    resourceId: String,
+    permissions: [String]
+});
+
+module.exports = mongoose.model('PermissionSet', permissionSetSchema);

--- a/src/server/api/router.js
+++ b/src/server/api/router.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const permissions = require('./routes/permissions');
+const users = require('./routes/users');
+
+router.use('/permissions', permissions);
+router.use('/users', users);
+
+module.exports = router;

--- a/src/server/api/routes/permissions.js
+++ b/src/server/api/routes/permissions.js
@@ -22,6 +22,10 @@ router.post('/:clientId/:resourceId', (req, res, next) => {
     let resourceId  = req.params.resourceId;
     let permissions = req.query.permission;
 
+    if (!Array.isArray(permissions)) {
+        permissions = [ permissions ];
+    }
+
     PermissionSet.find({clientId: clientId, resourceId: resourceId })
     .then(docs => {
         if (docs.length === 0) {
@@ -98,6 +102,7 @@ function saveNewPermissionSet(clientId, resourceId, permissions) {
 }
 
 function updatePermissionSet(permissionSet, permissions) {
+    console.log(permissions);
     permissions.forEach(permission => {
         permissionSet.permissions.addToSet( permission );
     })

--- a/src/server/api/routes/permissions.js
+++ b/src/server/api/routes/permissions.js
@@ -1,0 +1,108 @@
+const express = require('express');
+const router = express.Router();
+const mongoose = require('mongoose');
+
+const PermissionSet = require('../models/permissionSet');
+
+router.get('/', (req, res, next) => {
+    PermissionSet.find()
+    .exec()
+    .then(docs => {
+        console.log(docs);
+        res.status(200).json(docs);
+    })
+    .catch(err => {
+        console.log(err);
+        res.status(500).json({ error: err  });
+    });
+});
+
+router.post('/:clientId/:resourceId', (req, res, next) => {
+    let clientId    = req.params.clientId;
+    let resourceId  = req.params.resourceId;
+    let permissions = req.query.permission;
+
+    PermissionSet.find({clientId: clientId, resourceId: resourceId })
+    .then(docs => {
+        if (docs.length === 0) {
+            return saveNewPermissionSet(clientId, resourceId, permissions);
+        } else {
+            return updatePermissionSet(docs[0], permissions);
+        }
+    })
+    .then(result => {
+        console.log(result);
+        res.status(201).json({
+            message: "Handling POST requests to /permissionSets",
+            createdPermissionSet: result
+        });
+    })
+    .catch(err => {
+        console.log(err);
+        res.status(500).json({
+            error: err
+        });
+    });
+});
+
+router.get('/:clientId/:resourceId', (req, res, next) => {
+    const clientId      = req.params.clientId;
+    const resourceId    = req.params.resourceId;
+
+    PermissionSet.find({
+        clientId: clientId,
+        resourceId: resourceId
+    })
+    .exec()
+    .then(doc => {
+        console.log(doc);
+        if (doc) {
+            res.status(200).json(doc);
+        } else {
+            res.status(404).json({ message: 'No valid entry found for that client/resource pair' });
+        }
+    })
+    .catch(err => {
+        console.log(err);
+        res.status(500).json({ error: err });
+    });
+});
+
+router.delete("/:clientId/:resourceId", (req, res, next) => {
+    const clientId      = req.params.clientId;
+    const resourceId    = req.params.resourceId;
+
+    PermissionSet.remove({
+        clientId: clientId,
+        resourceId: resourceId
+    })
+    .exec()
+    .then(result => {
+        res.status(200).json(result);
+    })
+    .catch(err => {
+        console.log(err);
+        res.status(500).json({ error: err });
+    });
+});
+
+function saveNewPermissionSet(clientId, resourceId, permissions) {
+    const permissionSet = new PermissionSet({
+        _id: new mongoose.Types.ObjectId(),
+        clientId:    clientId, 
+        resourceId:  resourceId,
+        permissions: permissions
+    });
+
+    return permissionSet.save();
+}
+
+function updatePermissionSet(permissionSet, permissions) {
+    permissions.forEach(permission => {
+        permissionSet.permissions.addToSet( permission );
+    })
+
+    return permissionSet.save();
+}
+
+module.exports = router;

--- a/src/server/auth/static/js/app.js
+++ b/src/server/auth/static/js/app.js
@@ -25,6 +25,7 @@ $(function () {
     authToken.then(function setAuthToken(token) {
         if (token) {
             authToken = token;
+            window.localStorage.setItem('cognitoToken', token)
         } else {
             window.location.href = 'index.html';
         }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -26,6 +26,7 @@ mongoose.connect(
 
 securityFilter.registerTokenFilter(cognitoTokenFilter);
 securityFilter.registerPublicRoute('*:/api/permissions/*');
+securityFilter.registerPublicRoute('*:/auth/*');
 
 // Middleware
 app.use(morgan('dev')); // Used for logging requests

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,6 +8,9 @@ const mongoose = require('mongoose');
 const bodyParser = require('body-parser'); // TODO: Remove, depreciated.
 const dotenv = require("dotenv").config();
 
+const securityFilter = require('./security/securityFilter');
+const cognitoTokenFilter = require('./security/cognitoTokenFilter');
+
 const authProviderSingleton = require('./auth/api/v1_0_0/authProvider/AuthProvider').AuthProviderSingleton;
 authProviderSingleton.config = require('./auth/api/v1_0_0/config');
 authProviderSingleton.init();
@@ -21,9 +24,13 @@ mongoose.connect(
    "mongodb://badgebook-admin:" + process.env.MONGO_ATLAS_PASSWORD + "@badge-book-shard-00-00-7gbwk.mongodb.net:27017,badge-book-shard-00-01-7gbwk.mongodb.net:27017,badge-book-shard-00-02-7gbwk.mongodb.net:27017/test?ssl=true&replicaSet=badge-book-shard-0&authSource=admin&retryWrites=true"
 );
 
+securityFilter.registerTokenFilter(cognitoTokenFilter);
+securityFilter.registerPublicRoute('*:/api/permissions/*');
+
 // Middleware
-app.use(express.static('dist'));
 app.use(morgan('dev')); // Used for logging requests
+app.use(securityFilter);
+app.use(express.static('dist'));
 app.use(bodyParser.urlencoded({ extended: false })); // TODO: Remove, depreciated.
 app.use(bodyParser.json()); // TODO: Remove, depreciated.
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const app = express();
 const os = require('os');
 const auth = require('./auth/router');
+const apiRouter = require('./api/router');
 const morgan = require('morgan');
 const mongoose = require('mongoose');
 const bodyParser = require('body-parser'); // TODO: Remove, depreciated.
@@ -39,6 +40,7 @@ app.use((req, res, next) => {
 
 // Routes to handle requests
 app.use('/auth', auth);
+app.use('/api', apiRouter);
 app.use('/users', userRoutes);
 
 app.get('/api/getUsername', (req, res) => { // Remove this once users api is connected to frontend

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -24,16 +24,18 @@ mongoose.connect(
    "mongodb://badgebook-admin:" + process.env.MONGO_ATLAS_PASSWORD + "@badge-book-shard-00-00-7gbwk.mongodb.net:27017,badge-book-shard-00-01-7gbwk.mongodb.net:27017,badge-book-shard-00-02-7gbwk.mongodb.net:27017/test?ssl=true&replicaSet=badge-book-shard-0&authSource=admin&retryWrites=true"
 );
 
-securityFilter.registerTokenFilter(cognitoTokenFilter);
-securityFilter.registerPublicRoute('*:/api/permissions/*');
-securityFilter.registerPublicRoute('*:/auth/*');
-
 // Middleware
 app.use(morgan('dev')); // Used for logging requests
+
+// Set up security Filter
+securityFilter.registerTokenResolver(cognitoTokenFilter);
+securityFilter.registerPublicRoute('*:/api/permissions/*');
+securityFilter.registerPublicRoute('*:/auth/*');
+securityFilter.registerPublicRoute('*:/user/*');
+securityFilter.registerPublicRoute('*:/users/*');
 app.use(securityFilter);
+
 app.use(express.static('dist'));
-app.use(bodyParser.urlencoded({ extended: false })); // TODO: Remove, depreciated.
-app.use(bodyParser.json()); // TODO: Remove, depreciated.
 
 // Add CORS headers to request
 app.use((req, res, next) => {
@@ -50,10 +52,6 @@ app.use((req, res, next) => {
 app.use('/auth', auth);
 app.use('/api', apiRouter);
 app.use('/users', userRoutes);
-
-app.get('/api/getUsername', (req, res) => { // Remove this once users api is connected to frontend
-  res.send({ username: os.userInfo().username });
-});
 
 // Middleware to catch all errors
 app.use((req, res, next) => {

--- a/src/server/security/SecurityFilter.md
+++ b/src/server/security/SecurityFilter.md
@@ -1,0 +1,97 @@
+# Security Filter
+This is a quick piece of middleware that we can use to authenticate/authorize
+incoming requests to express.
+
+## Filtering Steps
+The SecurityFilter goes through the following steps:
+
+1. Extract the client ID from whatever token is placed in the `authorization`
+header (see [Token Resolvers](#token-resolvers)).
+2. Extract the resource ID by running the request object through any attached 
+[Resource Resolvers](#resource-resolvers).
+3. Use this pair to retrieve any relevant [permissions](#permissions) from our
+permissions database collection.
+4. Match the current request route against all returned permissions, plus any
+registered [public routes](#public-routes).
+5. If a match is found, the request passes through down the middleware chain.
+If not, a 401 response is returned.
+
+During this process, the security filter attaches the `clientId`, `resourceId`,
+and `permissions` objects to the ExpressJS `request` object. You can use these
+for whatever you feel like.
+
+### Notes
+- The token/resource resolvers are checked in order. As soon as one is found,
+they return. You shouldn't really be passing multiple resource IDs anyway
+(we can't handle this in our permission system), but it's something to be aware
+of.
+
+## Token Resolvers
+Token Resolvers are functions whose job is to extract a client ID from a
+specific type of token. They should return the extracted client ID if they were
+successful, or a falsey value if they weren't.
+
+**Prototype**
+```
+function MyTokenFilter(token) {
+    ...
+}
+```
+
+**To register a token resolver:**
+```
+securityFilter.registerTokenResolver(cognitoTokenFilter);
+```
+
+## Resource Resolvers
+Resource resolvers work similarly to [token resolvers](#token-resolvers). Their
+job is to find a resource ID (userID, appId, whatever) from _somewhere_ in an
+[ExpressJS request](https://expressjs.com/en/4x/api.html#req) object and return
+that resourceID (or a falsey value if none is found).
+
+**Prototype**
+```
+function MyResourceResolver(request) {
+    ...
+}
+```
+
+**To register a token resolver:**
+```
+securityFilter.registerResourceResolver(MyResourceResolver);
+```
+
+## Public Routes
+You can register public routes that are accessible to everyone by registering
+them with the security filter. Public routes are specified as strings, and the
+format is `METHOD:/path/to/resource`. Note that you can use `*` as wildcard
+characters.
+
+**To register a public route:**
+```
+securityFilter.registerPublicRoute('*:/auth/*');
+```
+
+**Note:** Even if a route is public, all the checks are still performed. I did
+this because A) it's simpler to implement, and B) the security filter attaches
+`clientId`, `resourceId`, and `permissions` to the ExpressJS `request` object.
+I figured we might want to use these later.
+
+## Permissions
+Permissions dictate what a particular "client" (whichever party sent the
+request to our server) can do with a particular "resource" (e.g., a user, or
+one of the external applications). There are three different parts:
+
+1. Client
+2. Resource
+3. Permission (what the client is actually allowed to do)
+
+Permissions follow one of two possible formats:
+
+1. `ROUTE:<METHOD>:</path/to/endpoint>` - These are for incoming requests.
+2. `SERVE:<badge/landing>` - These will be used by the main app when deciding
+whether or not to display one of the external app's data on a user's page.
+
+**Reference:**
+- You can find the schema for permissions under `src/server/api/models/permissionSet.js`
+- You can find the endpoints for setting/modifying under `src/server/api/routes/permissions.js`

--- a/src/server/security/cognitoTokenFilter.js
+++ b/src/server/security/cognitoTokenFilter.js
@@ -1,0 +1,26 @@
+const CognitoExpress = require('cognito-express');
+
+let cognitoExpress = new CognitoExpress({
+    region: 'us-west-2',
+    cognitoUserPoolId: 'us-west-2_eZyNHvuo4',
+    tokenUse: 'id'
+});
+
+function cognitoTokenFilter(token) {
+    return new Promise((resolve, reject) => {
+        cognitoExpress.validate(token, (err, jwt) => {
+            if (err) {
+                reject(`Invalid cognito token`);
+            }
+
+            try {
+                let user = jwt.sub;
+                resolve(user);
+            } catch (err) {
+                reject(err.message);
+            }
+        });
+    });
+}
+
+module.exports = cognitoTokenFilter;

--- a/src/server/security/securityFilter.js
+++ b/src/server/security/securityFilter.js
@@ -145,22 +145,29 @@ function lookupPermissions(clientId, resourceId) {
 }
 
 function isRouteAuthorized(route, method, permissions) {
-    let routePermissions = permissions.filter(permission => /^ROUTE:/.match(permission));
     let allowedRoutes = [].concat(publicRoutes);
-    routePermissions.forEach(permission => {
-        allowedRoutes.push(makeRouteRegExp(permission));
+
+    permissions.forEach(permission => {
+        if (! (/^ROUTE:/.test(permission))) { return; }
+        permissionStr = permission.slice(6);
+        allowedRoutes.push(makeRouteRegExp(permissionStr));
     });
 
     let incomingRoute   = `${method}:${route}`.toLowerCase();
     let matchingRule    = allowedRoutes.find(routeRule => routeRule.test(incomingRoute));
-
-    return Boolean(matchingRule);
+    let matches         = Boolean(matchingRule);
+    
+    // console.log('MATCHING', incomingRoute);
+    // console.log('ALLOWED ROUTES', allowedRoutes);
+    // console.log(matches);
+    return matches;
 }
 
 function makeRouteRegExp(str) {
     let regExpStr = str.toLowerCase();
-    regExpStr = regExpStr.split('/').join('\/');
     regExpStr = regExpStr.split('*').join('.*');
+    regExpStr = regExpStr.split('/.').join('[/.]');
+    regExpStr = regExpStr.split('/').join('\/');
     return new RegExp(`^${regExpStr}`);
 }
 

--- a/src/server/security/securityFilter.js
+++ b/src/server/security/securityFilter.js
@@ -54,7 +54,7 @@ async function securityFilter(req, res, next) {
 /**
  * Registers a token authenticator
  */
-securityFilter.registerTokenFilter = (tokenAuthenticator) => {
+securityFilter.registerTokenResolver = (tokenAuthenticator) => {
     tokenAuthenticators.push(tokenAuthenticator);
 };
 
@@ -156,7 +156,7 @@ function isRouteAuthorized(route, method, permissions) {
     let incomingRoute   = `${method}:${route}`.toLowerCase();
     let matchingRule    = allowedRoutes.find(routeRule => routeRule.test(incomingRoute));
     let matches         = Boolean(matchingRule);
-    
+
     // console.log('MATCHING', incomingRoute);
     // console.log('ALLOWED ROUTES', allowedRoutes);
     // console.log(matches);

--- a/src/server/security/securityFilter.js
+++ b/src/server/security/securityFilter.js
@@ -1,0 +1,170 @@
+const mongoose      = require('mongoose');
+const PermissionSet = require('../api/models/permissionSet');
+
+const tokenAuthenticators   = [];
+const resourcePaths         = [];
+const publicRoutes          = [];
+
+async function securityFilter(req, res, next) {
+    req.permissions = [];
+
+    try {
+        let clientToken = req.headers.authorization;
+        let clientId    = await getClientIdFromToken(clientToken);
+        req.clientId    = clientId;
+
+        let resourceId  = await getResourceId(req);
+        req.resourceId  = resourceId;
+
+        let permissions = [];
+        if (clientId) {
+            permissions = await lookupPermissions(clientId, resourceId);
+            req.permissions = permissions;
+        }
+    }
+    catch (err) {
+        console.log(err);
+    }
+
+    let route       = req.path;
+    let method      = req.method.toUpperCase();
+    let permissions = req.permissions;
+
+    if (isRouteAuthorized(route, method, permissions)) {
+        next();
+    } else {
+        res.status(401).json({
+            error:      'unauthorized',
+            clientId:   req.clientId    || 'undefined',
+            resourceId: req.resourceId  || 'undefined',
+            route:      req.path
+        });
+    }
+}
+
+/**
+ * Registers a token authenticator
+ */
+securityFilter.registerTokenFilter = (tokenAuthenticator) => {
+    tokenAuthenticators.push(tokenAuthenticator);
+};
+
+/**
+ * Resources (the things clients want to operate on) may exist in a bunch of
+ * possible places. Use this to register a path within the request object that
+ * should be searched.
+ * 
+ * Use:
+ * securityFilter.registerResourcePath(['headers','userid']);
+ */
+securityFilter.registerResourcePath = (path) => {
+    resourcePaths.push(path);
+};
+
+/**
+ * Registers a public route. These routes are not checked for permissions.
+ */
+securityFilter.registerPublicRoute = (route) => {
+    publicRoutes.push(makeRouteRegExp(route));
+};
+
+/**
+ * Tries to pull a client from the provided token.
+ * @param {String} clientToken Token to process
+ */
+async function getClientIdFromToken(clientToken) {
+    let client = '';
+    for (let i=0; i < tokenAuthenticators.length; i++) {
+        try {
+            client = await tokenAuthenticators[i](clientToken);
+
+            if (client) {
+                break;
+            }
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    if (!client) {
+        console.log('Invalid client id');
+    }
+
+    return client;
+}
+
+/**
+ * Tries to find a resource ID in the request object.
+ * @param {Request} req 
+ */
+function getResourceId(req) {
+    let resourceId = '';
+    for (let i=0; i < resourcePaths.length; i++) {
+        
+        let path    = resourcePaths[i];
+        let current = req;
+        for (let j=0; j < path.length; j++) {
+            if (current[path[j]]) {
+                current = current[path[j]];
+            } else {
+                current = null;
+                break;
+            }
+        }
+
+        if (current) {
+            resourceId = current;
+            break;
+        }
+    }
+
+    return resourceId;
+}
+
+/**
+ * Retrieves the permissions for the given clientId and resourceId.
+ */
+function lookupPermissions(clientId, resourceId) {
+    if (!resourceId) {
+        resourceId = 'na';
+    }
+
+    return PermissionSet.findOne({
+        clientId: clientId,
+        resourceId: resourceId
+    })
+    .exec()
+    .then(grant => {
+        if (grant) {
+            return grant.permissions;
+        } else {
+            return [];
+        }
+    })
+    .catch(err => {
+        console.log(err);
+        res.status(500).json({ error: err  });
+    });
+}
+
+function isRouteAuthorized(route, method, permissions) {
+    let routePermissions = permissions.filter(permission => /^ROUTE:/.match(permission));
+    let allowedRoutes = [].concat(publicRoutes);
+    routePermissions.forEach(permission => {
+        allowedRoutes.push(makeRouteRegExp(permission));
+    });
+
+    let incomingRoute   = `${method}:${route}`.toLowerCase();
+    let matchingRule    = allowedRoutes.find(routeRule => routeRule.test(incomingRoute));
+
+    return Boolean(matchingRule);
+}
+
+function makeRouteRegExp(str) {
+    let regExpStr = str.toLowerCase();
+    regExpStr = regExpStr.split('/').join('\/');
+    regExpStr = regExpStr.split('*').join('.*');
+    return new RegExp(`^${regExpStr}`);
+}
+
+module.exports = securityFilter;


### PR DESCRIPTION
This update:

1. Adds a piece of middleware to our Express app that security filtering based on permissions (full details in [SecurityFilter.md](https://github.com/cloudseption/profile-app/blob/b7acce5db1636bca77300bc9ba9a5c67f54449c6/src/server/security/SecurityFilter.md))
2. Adds userID extraction for any cognito tokens passed in through the `authorization` header.
3. Adds an additional router under `src/server/api/router.js` that puts all the API stuff under its own `/api/...` URL path (don't worry, I haven't removed any of the existing routes for users - there are just two ways to access those endpoints now).