### PR TITLE
Hotfix/heroku deployment timeout

### DIFF
--- a/launch-on-heroku.sh
+++ b/launch-on-heroku.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-echo "Loading deployment package"
-wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip
-unzip ./deployment_package.zip
-rm ./deployment_package.zip

--- a/launch-on-heroku.sh
+++ b/launch-on-heroku.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip
+unzip ./deployment_package.zip
+rm ./deployment_package.zip

--- a/launch-on-heroku.sh
+++ b/launch-on-heroku.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+echo "Loading deployment package"
 wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip
 unzip ./deployment_package.zip
 rm ./deployment_package.zip

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip && unzip ./deployment_package.zip && rm ./deployment_package.zip",
     "test": "mocha ./test/**/*.test.js"
   },
-  "author": "Sandeep Raveesh",
+  "author": "Cloudseption",
   "license": "ISC",
   "dependencies": {
     "@material-ui/core": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "client": "webpack-dev-server --color --progress --mode development -d",
     "server": "nodemon -r esm --watch src/server --inspect src/server/index.js",
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\"",
-    "heroku-postinstall": "wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip && unzip ./deployment_package.zip && rm ./deployment_package.zip",
+    "postinstall": "wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip && unzip ./deployment_package.zip && rm ./deployment_package.zip",
     "test": "mocha ./test/**/*.test.js"
   },
   "author": "Sandeep Raveesh",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "client": "webpack-dev-server --color --progress --mode development -d",
     "server": "nodemon -r esm --watch src/server --inspect src/server/index.js",
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\"",
-    "heroku-postinstall": "bash ./launch-on-heroku.sh",
+    "heroku-postinstall": "chmod +x ./launch-on-heroku.sh && ./launch-on-heroku.sh",
     "test": "mocha ./test/**/*.test.js"
   },
   "author": "Sandeep Raveesh",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "src/server/index.js",
   "scripts": {
     "build": "webpack --mode production",
-    "start": "npm run build && node src/server/index.js",
+    "start": "node src/server/index.js",
     "client": "webpack-dev-server --color --progress --mode development -d",
     "server": "nodemon -r esm --watch src/server --inspect src/server/index.js",
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\"",
-    "heroku-preinstall": "npm install -g webpack",
-    "heroku-postinstall": "npm install --dev && webpack -p",
+    "heroku-postinstall": "bash ./launch-on-heroku.sh",
     "test": "mocha ./test/**/*.test.js"
   },
   "author": "Sandeep Raveesh",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "client": "webpack-dev-server --color --progress --mode development -d",
     "server": "nodemon -r esm --watch src/server --inspect src/server/index.js",
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\"",
-    "heroku-postinstall": "chmod +x ./launch-on-heroku.sh && ./launch-on-heroku.sh",
+    "heroku-postinstall": "wget https://s3-us-west-2.amazonaws.com/cloudception-bucket/public/deployment_package.zip && unzip ./deployment_package.zip && rm ./deployment_package.zip",
     "test": "mocha ./test/**/*.test.js"
   },
   "author": "Sandeep Raveesh",

--- a/pre-deploy.sh
+++ b/pre-deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Prep deployment package
+npm run build
+zip -r deployment_package ./dist
+aws s3 cp ./deployment_package.zip s3://cloudception-bucket/public/
+rm ./deployment_package.zip


### PR DESCRIPTION
Fix for our deployment process.

**TLDR:** Changes build process so we build locally, store bundle in s3, and pull it to Heroku on launch.

**The Old Process:**
Consisted of deploying the development-version of the application and running webpack on the Heroku dyno. When pushing our most recent version of develop, this alternately caused one of two errors:

1) Either the app failed to bind to a port within 60 seconds (you have to file a customer support ticket to get them to change this, and the max is 120 seconds).
2) The app ran out of memory (we'd have to pay to fix this)

**The New Process:**
1) Runs `npm build` locally
2) Zips and pushes contents of `./dist` to S3
3) Cleans up
4) Modifies our npm scripts - now, instead of running webpack on the Heroku dyno, we `wget` the deployment package from s3 and unzip it.